### PR TITLE
Fix problem in league view, caused by blank gameweeks

### DIFF
--- a/assets/js/modules/leagues.js
+++ b/assets/js/modules/leagues.js
@@ -106,10 +106,16 @@ let leagues = {
           }
 
           let points = picks
-            .map((p) => ({
-              multiplier: p.multiplier,
-              data: this.liveData.elements[p.element].explain[0][0]
-            }))
+            .map((p) => {
+              let explain = this.liveData.elements[p.element].explain
+              // Handle players with Blank Gameweeks
+              let explainPoints = explain.length > 0 && explain[0].length > 0 ? explain[0][0] : { }
+
+              return {
+                multiplier: p.multiplier,
+                data: explainPoints
+              }
+            })
             .map((p, i) => {
               if (i > 10 && notBenchBoost)
                 return 0

--- a/assets/js/modules/leagues.js
+++ b/assets/js/modules/leagues.js
@@ -108,12 +108,10 @@ let leagues = {
           let points = picks
             .map((p) => {
               let explain = this.liveData.elements[p.element].explain
-              // Handle players with Blank Gameweeks
-              let explainPoints = explain.length > 0 && explain[0].length > 0 ? explain[0][0] : { }
 
               return {
                 multiplier: p.multiplier,
-                data: explainPoints
+                data: explain[0] !== undefined ? explain[0][0] : { }
               }
             })
             .map((p, i) => {


### PR DESCRIPTION
For a player that has a blank gameweek the API returns `{ elements: #: { explain: [ ] } }`. 

The empty `explain` array breaks the league standings view, showing correctly only rows of FPL players that have 0 players with a blank gameweek in their team.