### PR TITLE
Adjust leagues module for multi-gameweeks

### DIFF
--- a/assets/js/modules/leagues.js
+++ b/assets/js/modules/leagues.js
@@ -107,11 +107,24 @@ let leagues = {
 
           let points = picks
             .map((p) => {
-              let explain = this.liveData.elements[p.element].explain
+              // accumPoints evaluates to [] for Blank Gameweeks
+              // and sums 'points' and 'value' for multi-gameweeks
+              let accumPoints = this.liveData.elements[p.element].explain
+                .reduce((a, b) => {
+                  for (var key in b[0]) {
+                    if (key in a) {
+                      a[key].points += b[0][key].points
+                      a[key].value += b[0][key].value
+                    } else {
+                      a[key] = b[0][key]
+                    }
+                  }
+                  return a
+                }, { })
 
               return {
                 multiplier: p.multiplier,
-                data: explain[0] !== undefined ? explain[0][0] : { }
+                data: accumPoints
               }
             })
             .map((p, i) => {

--- a/assets/js/modules/leagues.js
+++ b/assets/js/modules/leagues.js
@@ -116,7 +116,11 @@ let leagues = {
                       a[key].points += b[0][key].points
                       a[key].value += b[0][key].value
                     } else {
-                      a[key] = b[0][key]
+                      a[key] = {
+                        name: b[0][key].name,
+                        points: b[0][key].points,
+                        value: b[0][key].value
+                      }
                     }
                   }
                   return a

--- a/assets/js/modules/leagues.js
+++ b/assets/js/modules/leagues.js
@@ -107,7 +107,7 @@ let leagues = {
 
           let points = picks
             .map((p) => {
-              // accumPoints evaluates to [] for Blank Gameweeks
+              // accumPoints evaluates to {} for Blank Gameweeks
               // and sums 'points' and 'value' for multi-gameweeks
               let accumPoints = this.liveData.elements[p.element].explain
                 .reduce((a, b) => {


### PR DESCRIPTION
Current logic will ignore the 2nd part of a DGW since `explain` array will contain 2 elements. This fix will work for BGWs, DGWs and the elusive TGW.